### PR TITLE
Add the platform environment variable to docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -208,6 +208,7 @@ services:
     #   docker-compose exec mysql bash -c 'mysql -u root -p$MYSQL_ROOT_PASSWORD'
     # *-----------------------------*
     image: mysql:8.0
+    platform: ${PLATFORM}
     container_name: workshop-mysql
     cpus: 0.5
     ports:
@@ -288,6 +289,7 @@ services:
 
   elastic:
     image: elasticsearch:7.6.2
+    platform: ${PLATFORM}
     hostname: elastic
     container_name: elastic
     ports:


### PR DESCRIPTION
I am preparing my environment for Confluent Cloud ksqlDB Hands-on Workshop on the 6th of May of 2021. However, I often get errors when lifting the containers, because platform assumptions are made, for instance:
```
Pulling elastic (elasticsearch:7.6.2)...
7.6.2: Pulling from library/elasticsearch
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
```
or 
```
Pulling mysql (mysql:8.0)...
8.0: Pulling from library/mysql
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
```
I was able to fix this issue by adding a PLATFORM environment variable to the docker-compose file to the two containers in which those errors were thrown, other colleagues attending this workshop had similar issues. Because we cannot know upfront which processor architecture the participant of the workshop will have, `linux/amd64`, `linux/arm64/32`, etc . I believe it makes sense for users to add request this environment variable before lifting the containers.
